### PR TITLE
MM-63235-Only prompt on private channels

### DIFF
--- a/webapp/channels/src/components/permalink_view/actions.ts
+++ b/webapp/channels/src/components/permalink_view/actions.ts
@@ -107,11 +107,13 @@ export function focusPost(postId: string, returnTo = '', currentUserId: string, 
             // Prompt system admins and team admins before joining the private channel
             const user = getCurrentUser(state);
             let prompt = false;
-            if (postInfo.channel_type === Constants.PRIVATE_CHANNEL && isSystemAdmin(user.roles)) {
-                prompt = true;
-            } else {
-                const teamMember = getMyTeamMember(state, currentTeam.id);
-                prompt = Boolean(teamMember && teamMember.scheme_admin);
+            if (postInfo.channel_type === Constants.PRIVATE_CHANNEL) {
+                if (isSystemAdmin(user.roles)) {
+                    prompt = true;
+                } else {
+                    const teamMember = getMyTeamMember(state, currentTeam.id);
+                    prompt = Boolean(teamMember && teamMember.scheme_admin);
+                }
             }
             if (prompt) {
                 privateChannelJoinPromptVisible = true;

--- a/webapp/channels/src/components/permalink_view/permalink_view.test.tsx
+++ b/webapp/channels/src/components/permalink_view/permalink_view.test.tsx
@@ -461,6 +461,57 @@ describe('components/PermalinkView', () => {
                     expect(testStore.getActions()).toEqual([]);
                 });
 
+                test('should not prompt team admin before redirect to public channel link', async () => {
+                    const testState = {
+                        ...initialState,
+                        entities: {
+                            ...initialState.entities,
+                            users: {
+                                ...initialState.entities.users,
+                                profiles: {
+                                    ...initialState.entities.users.profiles,
+                                    current_user_id: {
+                                        roles: 'system_user',
+                                    },
+                                },
+                            },
+                            teams: {
+                                ...initialState.entities.teams,
+                                myMembers: {
+                                    current_team_id: {
+                                        scheme_user: true,
+                                        scheme_admin: true,
+                                    },
+                                },
+                            },
+                        },
+                    };
+                    const postId = 'postid1';
+                    nockInfoForPost(postId);
+
+                    const testStore = await mockStore(testState);
+                    await testStore.dispatch(focusPost(postId, undefined, baseProps.currentUserId));
+
+                    expect(getPostThread).toHaveBeenCalledWith(postId);
+                    expect(testStore.getActions()).toEqual([
+                        {
+                            type: 'MOCK_GET_POST_THREAD',
+                            data: {
+                                posts: {
+                                    replypostid1: {id: 'replypostid1', message: 'some message', channel_id: 'channelid1', root_id: postId},
+                                    postid1: {id: postId, message: 'some message', channel_id: 'channelid1'},
+                                },
+                                order: [postId, 'replypostid1'],
+                            },
+                        },
+                        {type: 'MOCK_SELECT_CHANNEL', args: ['channelid1']},
+                        {type: 'RECEIVED_FOCUSED_POST', channelId: 'channelid1', data: postId},
+                        {type: 'MOCK_LOAD_CHANNELS_FOR_CURRENT_USER'},
+                        {type: 'MOCK_GET_CHANNEL_STATS', args: ['channelid1']},
+                    ]);
+                    expect(getHistory().replace).toHaveBeenCalledWith('/currentteam/channels/channel1/postid1');
+                });
+
                 test('should allow redirect to private channel link if prompt response true', async () => {
                     const testState = {
                         ...initialState,


### PR DESCRIPTION
Summary

A previous fix https://github.com/mattermost/mattermost/pull/29955, didn't check for private channel on new check. This PR ensures only private channels are prompted.

Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-63235